### PR TITLE
Add Prompt Guide to resources

### DIFF
--- a/pages/tools.en.mdx
+++ b/pages/tools.en.mdx
@@ -50,6 +50,7 @@
 - [Prompt Base](https://promptbase.com)
 - [PromptBench](https://github.com/microsoft/promptbench)
 - [Prompt Engine](https://github.com/microsoft/prompt-engine)
+- [Prompt Guide](https://prompt-guide.com) - Free, interactive prompt engineering platform with 300+ curated prompts, 30+ AI agent workflows, AI-evaluated exercises, and a glossary. Available in English and French.
 - [prompted.link](https://prompted.link)
 - [Prompter](https://prompter.engineer)
 - [PromptInject](https://github.com/agencyenterprise/PromptInject)


### PR DESCRIPTION
> **Copied from upstream:** [dair-ai/Prompt-Engineering-Guide#736](https://github.com/dair-ai/Prompt-Engineering-Guide/pull/736)
> **Original author:** @quentintou
> **Originally opened:** 2026-03-01

---

## Summary

- Adds [Prompt Guide](https://prompt-guide.com) to the Tools & Libraries page (`tools.en.mdx`)
- Placed alphabetically between "Prompt Engine" and "prompted.link"

## About Prompt Guide

[Prompt Guide](https://prompt-guide.com) is a free, interactive prompt engineering platform featuring:

- **300+ curated prompts** across various categories
- **30+ AI agent workflows** ready to use
- **AI-evaluated exercises** to practice prompt engineering
- **Comprehensive glossary** of prompt engineering terms
- Available in **English and French**

## Changes

- `pages/tools.en.mdx`: Added one line entry following the existing format