### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
> **Copied from upstream:** [dair-ai/Prompt-Engineering-Guide#723](https://github.com/dair-ai/Prompt-Engineering-Guide/pull/723)
> **Original author:** @pgoslatara
> **Originally opened:** 2026-01-21

---

This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/claude-code-review.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/claude.yml`
