### PR TITLE
Modified link for agenta under tools

### DIFF
--- a/ar-pages/tools.ar.mdx
+++ b/ar-pages/tools.ar.mdx
@@ -3,7 +3,7 @@
 #### (Sorted by Name)
 
 - [ActionSchema](https://actionschema.com)
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [AnySolve](https://www.anysolve.ai)
 - [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm)

--- a/pages/tools.ca.mdx
+++ b/pages/tools.ca.mdx
@@ -3,7 +3,7 @@
 #### (Ordenades per nom)
 
 - [ActionSchema](https://actionschema.com)
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
 - [Chainlit](https://github.com/chainlit/chainlit)

--- a/pages/tools.de.mdx
+++ b/pages/tools.de.mdx
@@ -3,7 +3,7 @@
 #### (Sortiert nach Namen)
 
 - [ActionSchema](https://actionschema.com)
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [AnySolve](https://www.anysolve.ai)
 - [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm)

--- a/pages/tools.en.mdx
+++ b/pages/tools.en.mdx
@@ -3,7 +3,7 @@
 #### (Sorted by Name)
 
 - [ActionSchema](https://actionschema.com)
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [AnySolve](https://www.anysolve.ai)
 - [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm)

--- a/pages/tools.es.mdx
+++ b/pages/tools.es.mdx
@@ -3,7 +3,7 @@
 #### (Ordenadas por nombre)
 
 - [ActionSchema](https://actionschema.com)
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
 - [Chainlit](https://github.com/chainlit/chainlit)

--- a/pages/tools.fi.mdx
+++ b/pages/tools.fi.mdx
@@ -3,7 +3,7 @@
 #### (Lajiteltu nimen perustella)
 
 - [ActionSchema](https://actionschema.com)
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/krrishdholakia/betterprompt)
 - [Chainlit](https://github.com/chainlit/chainlit)

--- a/pages/tools.fr.mdx
+++ b/pages/tools.fr.mdx
@@ -3,7 +3,7 @@
 #### (Trié par nom)
 
 - [ActionSchema](https://actionschema.com)
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
 - [Chainlit](https://github.com/chainlit/chainlit)

--- a/pages/tools.it.mdx
+++ b/pages/tools.it.mdx
@@ -3,7 +3,7 @@
 #### (In ordine alfabetico)
 
 - [ActionSchema](https://actionschema.com)
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
 - [Chainlit](https://github.com/chainlit/chainlit)

--- a/pages/tools.jp.mdx
+++ b/pages/tools.jp.mdx
@@ -3,7 +3,7 @@
 #### (名前順にソート（アルファベット順）)
 
 - [ActionSchema](https://actionschema.com)
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
 - [Chainlit](https://github.com/chainlit/chainlit)

--- a/pages/tools.kr.mdx
+++ b/pages/tools.kr.mdx
@@ -2,7 +2,7 @@
 
 #### (이름순 정렬)
 
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
 - [Chainlit](https://github.com/chainlit/chainlit)

--- a/pages/tools.pt.mdx
+++ b/pages/tools.pt.mdx
@@ -3,7 +3,7 @@
 #### (Sorteado por Nome)
 
 - [ActionSchema](https://actionschema.com)
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
 - [Chainlit](https://github.com/chainlit/chainlit)

--- a/pages/tools.ru.mdx
+++ b/pages/tools.ru.mdx
@@ -3,7 +3,7 @@
 #### (Отсортированные по имени)
 
 - [ActionSchema](https://actionschema.com)
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
 - [Chainlit](https://github.com/chainlit/chainlit)

--- a/pages/tools.tr.mdx
+++ b/pages/tools.tr.mdx
@@ -3,7 +3,7 @@
 #### (İsme Göre Sıralı)
 
 - [ActionSchema](https://actionschema.com)
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [AnySolve](https://www.anysolve.ai)
 - [betterprompt](https://github.com/stjordanis/betterprompt)

--- a/pages/tools.zh.mdx
+++ b/pages/tools.zh.mdx
@@ -3,7 +3,7 @@
 #### （按名称排序）
 
 - [ActionSchema](https://actionschema.com)
-- [Agenta](https://github.com/Agenta-AI/agenta)
+- [Agenta](https://agenta.ai)
 - [AI Test Kitchen](https://aitestkitchen.withgoogle.com)
 - [betterprompt](https://github.com/stjordanis/betterprompt)
 - [Chainlit](https://github.com/chainlit/chainlit)


### PR DESCRIPTION
> **Copied from upstream:** [dair-ai/Prompt-Engineering-Guide#612](https://github.com/dair-ai/Prompt-Engineering-Guide/pull/612)
> **Original author:** @mmabrouk
> **Originally opened:** 2025-02-05

---

I've updated the Agenta link from GitHub to our website. The website provides better information for new users (and tbh it will also help with our SEO). I hope this change is ok!

I've applied this update across all language versions.