### PR TITLE
chore: add langfuse to tools as an OSS option for monitoring/tracing/evals

### DIFF
--- a/pages/tools.en.mdx
+++ b/pages/tools.en.mdx
@@ -29,6 +29,7 @@
 - [Knit](https://promptknit.com)
 - [LangBear](https://langbear.runbear.io)
 - [LangChain](https://github.com/hwchase17/langchain)
+- [Langfuse](https://langfuse.com)
 - [LangSmith](https://docs.smith.langchain.com)
 - [Lexica](https://lexica.art)
 - [LMFlow](https://github.com/OptimalScale/LMFlow)


### PR DESCRIPTION
> **Copied from upstream:** [dair-ai/Prompt-Engineering-Guide#575](https://github.com/dair-ai/Prompt-Engineering-Guide/pull/575)
> **Original author:** @marcklingen
> **Originally opened:** 2024-10-07

---

